### PR TITLE
Explicitly read as UTF-8

### DIFF
--- a/emoji.py
+++ b/emoji.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
 	if len(sys.argv) == 1:
 		emojiEval(sys.stdin.read())
 	else:
-		h = open(sys.argv[1])
+		h = open(sys.argv[1], encoding="utf-8")
 		s = h.read()
 		h.close()
 		emojiEval(s, sys.argv[2:])


### PR DESCRIPTION
On Windows, Python defaults to Windows-1252 encoding for file reading and cannot read emojis correctly. This fixes that problem by explicitly declaring UTF-8 encoding.